### PR TITLE
Feature/spring boot classpath

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/WireMockConfig.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/WireMockConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,8 @@ public class WireMockConfig {
     private WireMockConfiguration wiremockOptions() {
         return options()
                 .port(port)
-                .usingFilesUnderDirectory("src/main/resources");
+                // work around for wiremock not reading from classpath of spring boot jars.
+                // see https://github.com/tomakehurst/wiremock/issues/725
+                .fileSource(new ClasspathFileSource("BOOT-INF/classes"));
     }
 }

--- a/src/main/java/uk/gov/dhsc/htbhf/WireMockConfig.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/WireMockConfig.java
@@ -27,6 +27,7 @@ public class WireMockConfig {
                 .port(port)
                 // work around for wiremock not reading from classpath of spring boot jars.
                 // see https://github.com/tomakehurst/wiremock/issues/725
-                .fileSource(new ClasspathFileSource("BOOT-INF/classes"));
+                .fileSource(new ClasspathFileSource("BOOT-INF/classes"))
+                .usingFilesUnderDirectory("src/main/resources");
     }
 }


### PR DESCRIPTION
- Adding support to read wiremock mappings from the classpath of a spring boot fat jar. See https://github.com/tomakehurst/wiremock/issues/725