### PR TITLE
HTBHF-1892 Added domain env variables to config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ jobs:
       APP_NAME: htbhf-os-places-stub
       SMOKE_TESTS: ./ci_scripts/smoke_tests.sh
       BIN_DIR: ./bin
+      CF_DOMAIN: apps.internal
+      CF_PUBLIC_DOMAIN: london.cloudapps.digital
+      CF_ORG: department-of-health-and-social-care
+      CF_API: api.london.cloud.service.gov.uk
+      BINTRAY_ROOT_URL: https://dl.bintray.com/departmentofhealth-htbhf/maven/uk/gov/dhsc/htbhf
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
These variables are currently configured in circleci UI, but they're hidden there. Much better in config. We should look at moving all similar variables in other projects.